### PR TITLE
fix: fix error "Argument 'name' is required" on call help command

### DIFF
--- a/go-script.go
+++ b/go-script.go
@@ -175,10 +175,10 @@ func (s *Script) Build() *Script {
 	}
 
 	s.parseInput()
-	s.validateInput()
 	s.findOutputVerbosity()
-
 	s.handleHelpCall()
+
+	s.validateInput()
 
 	if s.Runner != nil {
 		os.Exit(int(s.Runner(s)))


### PR DESCRIPTION
Hi

Now, when calling any command with required arguments, the error `[ERROR] Argument 'name' is required` appears.

This occurs because input validation is performed before handling the help command.

![error](https://github.com/DrSmithFr/go-console/assets/8027278/3ed9fa45-8479-4991-9f59-7a7f1127bbb3)

Code snippet
```go
func main() {
	cmd := go_console.Command{
		Scripts: []*go_console.Script{
			{
				Name: "test",
				Arguments: []go_console.Argument{
					{
						Name:  "first",
						Value: argument.Required,
					},
				},
				Runner: func(cmd *go_console.Script) go_console.ExitCode {
					fmt.Println("testing")

					return go_console.ExitSuccess
				},
			},
		},
	}

	cmd.Run()
}
```
