### PR TITLE
fix: fix calling command version

### DIFF
--- a/go-script.go
+++ b/go-script.go
@@ -418,6 +418,10 @@ func (s *Script) handleHelpCall() {
 }
 
 func (s *Script) handleVersionCall() {
+	if s.input.Option("version") == option.Undefined {
+		return
+	}
+
 	// deprecated but still supported and prior to other options
 	cmdName := s.Name
 


### PR DESCRIPTION
Hi.

The version is now displayed when calling the command without `--version`. 

This request adds a condition to display the version.

**Reproduction**

Code:
```go
func main() {
	cmd := &goconsole.Command{
		Scripts: []*goconsole.Script{
			{
				Name: "test",
				Runner: func(cmd *goconsole.Script) goconsole.ExitCode {
					return goconsole.ExitSuccess
				},
			},
		},
	}

	cmd.Run()
}
```

Result:

```
go run main.go test
/var/folders/rh/4r3n0z2d72xb3r1tp1d0dt5h0000gp/T/go-build173302586/b001/exe/main test@latest
```